### PR TITLE
Add headers parameter to get()

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,7 +251,7 @@ function imagist (opts = {}) {
     return false
   }
 
-  async function get (param, query) {
+  async function get (param, query, headers = {}) {
     if (!param) {
       throw new TypeError('Source path is missing.')
     }
@@ -270,7 +270,7 @@ function imagist (opts = {}) {
       throw new TypeError('Host not allowed.')
     }
 
-    const stream = await mhttp.getStream({ url: url.href })
+    const stream = await mhttp.getStream({ url: url.href, headers })
     const [reader, mimeType] = await _streamMimeType(stream)
     return _processImage(reader, mimeType, query)
   }

--- a/index.js
+++ b/index.js
@@ -251,7 +251,7 @@ function imagist (opts = {}) {
     return false
   }
 
-  async function get (param, query, headers = {}) {
+  async function get (param, query, settings = {}) {
     if (!param) {
       throw new TypeError('Source path is missing.')
     }
@@ -263,6 +263,9 @@ function imagist (opts = {}) {
     if (_options.host) {
       _options.whitelist.push(_options.host)
     }
+    
+    const defaultSettings = { headers: {} }
+    settings = { ...defaultSettings, ...settings }
 
     let url = _parseUrl(param)
 
@@ -270,7 +273,10 @@ function imagist (opts = {}) {
       throw new TypeError('Host not allowed.')
     }
 
-    const stream = await mhttp.getStream({ url: url.href, headers })
+    const stream = await mhttp.getStream({
+      url: url.href,
+      headers: settings.headers
+    })
     const [reader, mimeType] = await _streamMimeType(stream)
     return _processImage(reader, mimeType, query)
   }


### PR DESCRIPTION
This PR enables you to pass your own headers back to the [mhttp `getStream()`](https://node-machine.org/machinepack-http/get-stream)